### PR TITLE
masterへのcommit制限

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+﻿# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+    -   id: no-commit-to-branch # 特定のブランチへのcommitを制限する
+        args: [--branch, master]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# 初期設定
+**開発開始前に必ず以下設定してください**
+## pre-commit
+*masterへのcommitを禁止します。*<br>
+参考<br>
+https://docs.google.com/spreadsheets/d/1pplrfImx4ros5TMD3TbqYJ_EUxaDR7FL/edit#gid=1375961712<br>
+1.`pip install pre-commit`<br>
+2.パスを通す<br>
+3.`pre-commit --version`<br>
+4.`pre-commit install`<br>


### PR DESCRIPTION
※必要があれば画面共有で説明させていただきながら、レビューいただければと思っております。

それぞれ以下の役割を持つファイルです。

■.pre-commit-config.yaml
→pre-commitコマンドを使用してmasterへのcommitを制限するための設定ファイル

■README.md
→新規参画者用の説明書き。masterへのcommitの制限を各個人の環境に反映させるための簡単な手順

反映した状態を以下に作ってありますので、ご確認いただければと思います。
https://github.com/Kizuna-study-7980/public_html_test